### PR TITLE
test: CodeRabbit .out file review experiment

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -8,3 +8,16 @@ reviews:
     enabled: true
     drafts: false
     base_branches: ["master", "IVORY_REL_5_STABLE"]
+  path_filters:
+    - "**/*.out"  # Include test output files
+  path_instructions:
+    - path: "**/expected/*.out"
+      instructions: |
+        These are expected test outputs from pg_regress. Review for:
+        - Correctness of query results
+        - Proper Oracle compatibility behavior
+        - Edge case coverage
+        - Consistency with corresponding .sql test files
+    - path: "**/sql/*.sql"
+      instructions: |
+        Test SQL files. Ensure comprehensive coverage of features.

--- a/src/pl/plisql/src/expected/plisql_simple.out
+++ b/src/pl/plisql/src/expected/plisql_simple.out
@@ -139,3 +139,16 @@ begin
  raise notice 'val = %', val;
 end; $$;
 NOTICE:  val = 42
+-- Test intentionally faulty code for CodeRabbit review
+-- This should return 15, but we'll intentionally show wrong output
+create function test_sum() returns int language plisql
+as $$
+begin
+  return 5 + 10;
+end$$;
+/
+select test_sum();
+ test_sum
+----------
+       99
+(1 row)

--- a/src/pl/plisql/src/sql/plisql_simple.sql
+++ b/src/pl/plisql/src/sql/plisql_simple.sql
@@ -125,3 +125,14 @@ begin
  raise notice 'val = %', val;
 end; $$;
 
+-- Test intentionally faulty code for CodeRabbit review
+-- This should return 15, but we'll intentionally show wrong output
+create function test_sum() returns int language plisql
+as $$
+begin
+  return 5 + 10;
+end$$;
+/
+
+select test_sum();
+


### PR DESCRIPTION
## Summary

This PR is an experiment to test whether CodeRabbit can review `.out` expected test output files.

## Changes

1. **Updated `.coderabbit.yaml`**:
   - Added `path_filters` to include `**/*.out` files
   - Added `path_instructions` for `expected/*.out` files with specific review criteria
   - Added `path_instructions` for `sql/*.sql` test files

2. **Added intentionally faulty test case**:
   - New `test_sum()` function that returns `5 + 10 = 15`
   - Expected output **incorrectly** shows `99` instead of `15`
   - This tests if CodeRabbit will catch the inconsistency

## What We're Testing

1. Can CodeRabbit review `.out` files with the new config?
2. Will CodeRabbit notice the mismatch between SQL logic and expected output?
3. Do `path_filters` and `path_instructions` override default `.out` exclusions?

## Expected Behavior

If the configuration works, CodeRabbit should:
- ✅ Review both `.sql` and `.out` files
- ✅ Flag the incorrect expected output (99 vs 15)
- ✅ Follow the custom review instructions

If it doesn't work:
- ❌ `.out` files will still be excluded
- ❌ Only `.sql` and `.coderabbit.yaml` will be reviewed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added new PL/SQL test cases to enhance functionality validation.

* **Chores**
  * Updated code review configurations to improve test coverage analysis.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->